### PR TITLE
Sort by leaderbord wealth bug fix

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -232,7 +232,32 @@ const leaderboardFixtures = {
             "cowsSold": 60,
             "cowDeaths": 60
         }
-    ]
+    ],
+    sortingBugCommonsLB:
+    [
+        {
+            "id":1,
+            "userId": 1,
+            "username": "lessWealth",
+            "commonsId": 1,
+            "totalWealth" : 595,
+            "numOfCows": 8,
+            "cowsBought": 8,
+            "cowsSold": 8,
+            "cowDeaths": 8
+        },
+        {
+            "id":2,
+            "userId": 2,
+            "username": "moreWealth",
+            "commonsId": 1,
+            "totalWealth" : 10000,
+            "numOfCows": 5,
+            "cowsBought": 5,
+            "cowsSold": 5,
+            "cowDeaths": 5
+        },
+    ],
 }
 
 export default leaderboardFixtures;

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -20,10 +20,10 @@ export default function LeaderboardTable({ leaderboardUsers }) {
             Header: "Total Wealth",
             id: "totalWealth",
             accessor: (row, _rowIndex) => {
-                return USD.format(row.totalWealth);
+                return row.totalWealth;
             },
             Cell: (props) => {
-                return <div style={{ textAlign: "right" }}>{props.value}</div>;
+                return <div style={{ textAlign: "right" }}>{USD.format(props.value)}</div>;
             },
         },
         {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -210,4 +210,35 @@ describe("LeaderboardTable tests", () => {
         // Assert the expected URL based on your data
         expect(window.location.href).toBe("http://localhost/");
     });
+
+    test("Sort by wealth should have rows appear in the correct order", async () => {
+        const testId = "LeaderboardTable";
+        const currentUser = currentUserFixtures.adminUser;
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardTable
+                        leaderboardUsers={leaderboardFixtures.sortingBugCommonsLB}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const wealthHeader = screen.getByTestId(`${testId}-header-totalWealth`)
+
+        fireEvent.click(wealthHeader);
+        expect(await screen.findByText("🔼")).toBeInTheDocument();
+        const rows = screen.getAllByTestId(/^LeaderboardTable-cell-row-\d+-col-Farmer$/);
+        const rowTexts = rows.map((row) => row.textContent);
+        expect(rowTexts).toEqual(["lessWealth", "moreWealth"]);
+
+
+        fireEvent.click(wealthHeader);
+        expect(await screen.findByText("🔽")).toBeInTheDocument();
+        const rowsAfterDescSort = screen.getAllByTestId(/^LeaderboardTable-cell-row-\d+-col-Farmer$/);
+        const rowTextsDesc = rowsAfterDescSort.map((row) => row.textContent);
+        expect(rowTextsDesc).toEqual(["moreWealth", "lessWealth"]);
+
+    });
 });


### PR DESCRIPTION
## Overview
Fixes the bug where sorting by wealth on the leaderboard incorrectly ranks users with less than $1000 total wealth. 

## Screenshots (Optional)
As you can see, the sorting is working properly under the conditions described in the issue:
![image](https://github.com/user-attachments/assets/3d9cec85-d24e-47ae-908e-58560d1d7c03)
![image](https://github.com/user-attachments/assets/97d6e276-a333-419b-a372-b4840431966c)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Run this branch and log in with 2 different accounts. Reduce one user's wealth below $1000 and sort the leaderboard by wealth.

## Deployment
I've logged in to two different accounts on this deployment in the commons called "test for sorting bug" to showcase that the leaderboard sorting works.
https://happycows-qa.dokku-12.cs.ucsb.edu/

## Linked Issues
<!--Issues related to the PR-->
Closes #12 
