### PR TITLE
Fixed visual ugliness on profits table

### DIFF
--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -13,7 +13,7 @@ const PagedProfitsTable = () => {
 
     const [selectedPage, setSelectedPage] = React.useState(0);
 
-    const PROFIT_PAGE_SIZE = 6;
+    const PROFIT_PAGE_SIZE = 5;
     const { commonsId } = useParams();
 
     // Stryker disable all
@@ -96,7 +96,6 @@ const PagedProfitsTable = () => {
                         columns={columns}
                         testid={testid}
                         initialState={{ sortBy: sortees }}
-            
                     />
             </div>
         </>

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -90,7 +90,7 @@ const PagedProfitsTable = () => {
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
-            <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'row' }}>
+            <div style={{display: 'flex'}}>
                     < OurTable
                         data={page.content}
                         columns={columns}

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -90,7 +90,7 @@ const PagedProfitsTable = () => {
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
-            // Stryker disable next-line all : don't test CSS params
+            {/* Stryker disable next-line all : don't test CSS params*/}
             <div style={{display: 'flex'}}>
                     < OurTable
                         data={page.content}

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -90,6 +90,7 @@ const PagedProfitsTable = () => {
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            // Stryker disable next-line all : don't test CSS params
             <div style={{display: 'flex'}}>
                     < OurTable
                         data={page.content}

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -90,8 +90,10 @@ const PagedProfitsTable = () => {
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
-            {/* Stryker disable next-line all : don't test CSS params*/}
-            <div style={{display: 'flex'}}>
+            <div 
+                data-testid="PagedProfitsTable-container" 
+                style={{display: 'flex'}}
+            >
                     < OurTable
                         data={page.content}
                         columns={columns}

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -13,7 +13,7 @@ const PagedProfitsTable = () => {
 
     const [selectedPage, setSelectedPage] = React.useState(0);
 
-    const PROFIT_PAGE_SIZE = 5;
+    const PROFIT_PAGE_SIZE = 6;
     const { commonsId } = useParams();
 
     // Stryker disable all
@@ -90,13 +90,15 @@ const PagedProfitsTable = () => {
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
-            < OurTable
-                data={page.content}
-                columns={columns}
-                testid={testid}
-                initialState={{ sortBy: sortees }}
-
-            />
+            <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'row' }}>
+                    < OurTable
+                        data={page.content}
+                        columns={columns}
+                        testid={testid}
+                        initialState={{ sortBy: sortees }}
+            
+                    />
+            </div>
         </>
     );
 }; 

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -26,10 +26,10 @@ export default function ProfitsTable({ profits }) {
     []);
     const memoizedDates = React.useMemo(() => profits, [profits]);
     // Stryker restore ArrayDeclaration
-
-    return <OurTable
-        data={memoizedDates}
-        columns={memoizedColumns}
-        testid={"ProfitsTable"}
-    />;
+    <OurTable
+    data={memoizedDates}
+    columns={memoizedColumns}
+    testid={"ProfitsTable"}
+    />
+    
 };

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -26,10 +26,10 @@ export default function ProfitsTable({ profits }) {
     []);
     const memoizedDates = React.useMemo(() => profits, [profits]);
     // Stryker restore ArrayDeclaration
-    <OurTable
-    data={memoizedDates}
-    columns={memoizedColumns}
-    testid={"ProfitsTable"}
-    />
-    
+
+    return <OurTable
+        data={memoizedDates}
+        columns={memoizedColumns}
+        testid={"ProfitsTable"}
+    />;
 };

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -196,5 +196,22 @@ describe("PagedProfitsTable tests", () => {
 
   });
 
+  test("displayed with flex style", async () => {
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const divElement = screen.getByTestId('PagedProfitsTable-container');
+    expect(window.getComputedStyle(divElement).display).toBe('flex');
+  }); 
+  
+
 
     });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
The Profits table no longer has ugly whitespace.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/user-attachments/assets/8a3addcf-6e9b-4286-b64a-1d82a46809b2)

## Deployment
https://happycows-dev-jzipkin1812.dokku-12.cs.ucsb.edu/

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Run the project on this branch and simply view the profits table on the Play page.

## Tests
<!--Add any additional tests or required tests-->
A very simple test was added to PagedProfitsTable.test.js to make sure that the style of the component was "flex" as was needed to eliminate the whitespace. No other tests had to be modified nor were they affected since the text content of the table was unaffected.

## Linked Issues
<!--Issues related to the PR-->
Closes #14 
