### PR TITLE
Issue 16 - Change link of Mattanjah de Vries in footer

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -5,7 +5,7 @@ export default function Footer({systemInfo}) {
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
-          HappyCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
+          HappyCows is a project of <a href="https://devries.chem.ucsb.edu/about-5">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara. 
           The open source code is <a data-testid="github-href" href={systemInfo?.sourceRepo}>available on GitHub</a>. 
         </p>


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the "Mattanjah de Vries" link is changed. Before the change, the link leads to this out-dated website: https://devries.chem.ucsb.edu/mattanjah-de-vries. After the change, the link leads to the actual About page: https://devries.chem.ucsb.edu/about-5.

## Tests
<!--Add any additional tests or required tests-->
- [o ] Backend Unit tests (`mvn test`) pass
- [ o] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ o] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [o ] Frontend Unit tests (`npm test`) pass
- [ o] Frontend Test coverage (`npm run coverage`) 100%
- [o ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ o] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #16 
