### PR TITLE
yx - Fixed Create Announcements Post

### DIFF
--- a/frontend/src/main/components/Announcement/AnnouncementForm.js
+++ b/frontend/src/main/components/Announcement/AnnouncementForm.js
@@ -3,36 +3,37 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+    const navigate = useNavigate();
+    const testIdPrefix = "AnnouncementForm";
 
-    // Stryker disable all
+    // Initialize React Hook Form
     const {
         register,
         formState: { errors },
         handleSubmit,
+        watch,
     } = useForm({
         defaultValues: {
-            ...initialContents,
-            startDate: initialContents?.startDate || "",
+            startDate: initialContents?.startDate || new Date().toISOString(),
+            endDate: initialContents?.endDate || "",
+            announcementText: initialContents?.announcementText || "",
         },
     });
-    // Stryker restore all
 
-    const navigate = useNavigate();
-    const testIdPrefix = "AnnouncementForm";
+    // Watch form fields to ensure values are controlled
+    const startDate = watch("startDate");
+    const endDate = watch("endDate");
 
     const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
 
-    // Get the current date-time formatted for datetime-local inputs
-    const getCurrentDateTime = () => {
-        const now = new Date();
-        return now.toISOString().slice(0, 16); // Matches `datetime-local` format
-    };
-
     const onSubmit = (data) => {
-        if (!data.startDate) {
-            data.startDate = new Date().toISOString(); // Default to current datetime if not provided
-        }
-        submitAction(data);
+        const formattedData = {
+            ...data,
+            // Convert dates to include the timezone offset
+            startDate: data.startDate ? new Date(data.startDate).toISOString() : null,
+            endDate: data.endDate ? new Date(data.endDate).toISOString() : null,
+        };
+        submitAction(formattedData);
     };
 
     return (
@@ -41,7 +42,6 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                 <Form.Group className="mb-3">
                     <Form.Label htmlFor="id">Id</Form.Label>
                     <Form.Control
-                        // Stryker disable next-line all
                         data-testid={`${testIdPrefix}-id`}
                         id="id"
                         type="text"
@@ -54,14 +54,12 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="startDate">
-                    Start Date <small>(defaults to current time)</small> {/* Explanation added */}
+                    Start Date <small>(defaults to current time)</small>
                 </Form.Label>
                 <Form.Control
-                    // Stryker disable next-line all
                     data-testid={`${testIdPrefix}-startDate`}
                     id="startDate"
                     type="datetime-local"
-                    placeholder={getCurrentDateTime()} // Placeholder for current datetime
                     isInvalid={Boolean(errors.startDate)}
                     {...register("startDate", {
                         pattern: {
@@ -69,6 +67,7 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                             message: "Start Date must be in ISO format.",
                         },
                     })}
+                    defaultValue={startDate}
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.startDate?.message}
@@ -78,7 +77,6 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="endDate">End Date</Form.Label>
                 <Form.Control
-                    // Stryker disable next-line all
                     data-testid={`${testIdPrefix}-endDate`}
                     id="endDate"
                     type="datetime-local"
@@ -89,14 +87,17 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                             message: "End Date must be in ISO format.",
                         },
                     })}
+                    defaultValue={endDate}
                 />
+                <Form.Control.Feedback type="invalid">
+                    {errors.endDate?.message}
+                </Form.Control.Feedback>
             </Form.Group>
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="announcementText">Announcement</Form.Label>
                 <Form.Control
                     as="textarea"
-                    // Stryker disable next-line all
                     data-testid={`${testIdPrefix}-announcementText`}
                     id="announcementText"
                     rows={5}
@@ -104,6 +105,7 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                     {...register("announcementText", {
                         required: "Announcement is required.",
                     })}
+                    defaultValue={initialContents?.announcementText || ""}
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.announcementText?.message}
@@ -112,7 +114,6 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
 
             <Button
                 type="submit"
-                // Stryker disable next-line all
                 data-testid={`${testIdPrefix}-submit`}
             >
                 {buttonLabel}
@@ -120,7 +121,6 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
             <Button
                 variant="Secondary"
                 onClick={() => navigate(-1)}
-                // Stryker disable next-line all
                 data-testid={`${testIdPrefix}-cancel`}
             >
                 Cancel

--- a/frontend/src/main/components/Announcement/AnnouncementForm.js
+++ b/frontend/src/main/components/Announcement/AnnouncementForm.js
@@ -1,6 +1,6 @@
 import { Button, Form } from 'react-bootstrap';
-import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
@@ -9,34 +9,40 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
         register,
         formState: { errors },
         handleSubmit,
-    } = useForm(
-        { defaultValues: initialContents || {}, }
-    );
+    } = useForm({
+        defaultValues: {
+            ...initialContents,
+            startDate: initialContents?.startDate || "",
+        },
+    });
     // Stryker restore all
 
     const navigate = useNavigate();
-
     const testIdPrefix = "AnnouncementForm";
 
-    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
-    // Note that even this complex regex may still need some tweaks
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
 
-    // Stryker disable next-line Regex
-    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+    // Get the current date-time formatted for datetime-local inputs
+    const getCurrentDateTime = () => {
+        const now = new Date();
+        return now.toISOString().slice(0, 16); // Matches `datetime-local` format
+    };
 
-    // Stryker disable next-line all
-    //const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
+    const onSubmit = (data) => {
+        if (!data.startDate) {
+            data.startDate = new Date().toISOString(); // Default to current datetime if not provided
+        }
+        submitAction(data);
+    };
 
     return (
-
-        <Form onSubmit={handleSubmit(submitAction)}>
-
+        <Form onSubmit={handleSubmit(onSubmit)}>
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="id">Id</Form.Label>
                     <Form.Control
-                    // Stryker disable next-line all
-                        data-testid={testIdPrefix + "-id"}
+                        // Stryker disable next-line all
+                        data-testid={`${testIdPrefix}-id`}
                         id="id"
                         type="text"
                         {...register("id")}
@@ -46,51 +52,57 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                 </Form.Group>
             )}
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="startDate">Start Date</Form.Label>
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="startDate">
+                    Start Date <small>(defaults to current time)</small> {/* Explanation added */}
+                </Form.Label>
                 <Form.Control
-                // Stryker disable next-line all
-                    data-testid={testIdPrefix + "-startDate"}
+                    // Stryker disable next-line all
+                    data-testid={`${testIdPrefix}-startDate`}
                     id="startDate"
                     type="datetime-local"
+                    placeholder={getCurrentDateTime()} // Placeholder for current datetime
                     isInvalid={Boolean(errors.startDate)}
                     {...register("startDate", {
-                        required: "StartDate is required.",
-                        pattern: isodate_regex
+                        pattern: {
+                            value: isodate_regex,
+                            message: "Start Date must be in ISO format.",
+                        },
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.startDate && 'Start Date is required and must be provided in ISO format.'}
+                    {errors.startDate?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className="mb-3" >
+            <Form.Group className="mb-3">
                 <Form.Label htmlFor="endDate">End Date</Form.Label>
                 <Form.Control
-                // Stryker disable next-line all
-                    data-testid={testIdPrefix + "-endDate"}
+                    // Stryker disable next-line all
+                    data-testid={`${testIdPrefix}-endDate`}
                     id="endDate"
                     type="datetime-local"
                     isInvalid={Boolean(errors.endDate)}
-                    // Stryker disable next-line all
                     {...register("endDate", {
-                        pattern: isodate_regex
+                        pattern: {
+                            value: isodate_regex,
+                            message: "End Date must be in ISO format.",
+                        },
                     })}
                 />
             </Form.Group>
-
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="announcementText">Announcement</Form.Label>
                 <Form.Control
                     as="textarea"
                     // Stryker disable next-line all
-                    data-testid={testIdPrefix + "-announcementText"}
+                    data-testid={`${testIdPrefix}-announcementText`}
                     id="announcementText"
                     rows={5}
                     isInvalid={Boolean(errors.announcementText)}
                     {...register("announcementText", {
-                        required: "Announcement is required."
+                        required: "Announcement is required.",
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -101,7 +113,7 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
             <Button
                 type="submit"
                 // Stryker disable next-line all
-                data-testid={testIdPrefix + "-submit"}
+                data-testid={`${testIdPrefix}-submit`}
             >
                 {buttonLabel}
             </Button>
@@ -109,13 +121,12 @@ function AnnouncementForm({ initialContents, submitAction, buttonLabel = "Create
                 variant="Secondary"
                 onClick={() => navigate(-1)}
                 // Stryker disable next-line all
-                data-testid={testIdPrefix + "-cancel"}
+                data-testid={`${testIdPrefix}-cancel`}
             >
                 Cancel
             </Button>
-
         </Form>
-    )
+    );
 }
 
 export default AnnouncementForm;

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,13 +1,70 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Navigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import { useParams } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { useBackend } from "main/utils/useBackend";
+import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
 
-export default function AdminCreateAnnouncementsPage() {
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Create Announcement</h1>
-                <h2>Not implemented yet; coming soon!</h2>
-            </div>
-        </BasicLayout>
-    )
-}
+const AdminCreateAnnouncementPage = () => {
+  const objectToAxiosParams = (newAnnouncement) => ({
+    url: "/api/announcements/new",
+    method: "POST",
+    data: newAnnouncement,
+  });
+
+  const { commonsId } = useParams();
+
+  const { data: commonsPlus } = useBackend(
+    [`/api/commons/plus?id=${commonsId}`],
+    {
+        method: "GET",
+        url: "/api/commons/plus",
+        params: {
+            id: commonsId,
+        },
+    }
+);
+
+const commonsName = commonsPlus?.commons.name;
+
+  // Success handler
+  const onSuccess = (announcement) => {
+    toast(
+      <div>
+        <p>Announcement successfully created!</p>
+        <ul>
+          <li>{`ID: ${announcement.id}`}</li>
+          <li>{`Start Date: ${announcement.startDate}`}</li>
+          <li>{`End Date: ${announcement.endDate}`}</li>
+          <li>{`Announcement: ${announcement.message}`}</li>
+        </ul>
+      </div>
+    );
+  };
+
+  // Backend mutation hook
+  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
+    "/api/announcements/all",
+  ]);
+
+  // Form submission handler
+  const submitAction = async (data) => {
+    mutation.mutate(data);
+  };
+
+  // Redirect after successful submission
+  if (mutation.isSuccess) {
+    return <Navigate to="/" />;
+  }
+
+  return (
+    <BasicLayout>
+      <h2>Create Announcement for { commonsName} </h2>
+      <AnnouncementForm submitAction={submitAction} />
+    </BasicLayout>
+  );
+};
+
+export default AdminCreateAnnouncementPage;

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,70 +1,77 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { Navigate } from "react-router-dom";
-import { toast } from "react-toastify";
-import { useParams } from "react-router-dom";
-import { useBackendMutation } from "main/utils/useBackend";
-import { useBackend } from "main/utils/useBackend";
 import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
+import { useParams, Navigate } from 'react-router-dom'
+import { toast } from "react-toastify"
 
-const AdminCreateAnnouncementPage = () => {
-  const objectToAxiosParams = (newAnnouncement) => ({
-    url: "/api/announcements/new",
-    method: "POST",
-    data: newAnnouncement,
-  });
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
 
-  const { commonsId } = useParams();
+// Stryker disable all
+const AdminCreateAnnouncementsPage = () => {
 
-  const { data: commonsPlus } = useBackend(
-    [`/api/commons/plus?id=${commonsId}`],
-    {
-        method: "GET",
-        url: "/api/commons/plus",
-        params: {
-            id: commonsId,
-        },
-    }
-);
+    const objectToAxiosParams = (newAnnouncement) => ({
+        url: "/api/announcements/new",
+        method: "POST",
+        data: newAnnouncement
+    });
 
-const commonsName = commonsPlus?.commons.name;
+    const { commonsId } = useParams(); 
 
-  // Success handler
-  const onSuccess = (announcement) => {
-    toast(
-      <div>
-        <p>Announcement successfully created!</p>
-        <ul>
-          <li>{`ID: ${announcement.id}`}</li>
-          <li>{`Start Date: ${announcement.startDate}`}</li>
-          <li>{`End Date: ${announcement.endDate}`}</li>
-          <li>{`Announcement: ${announcement.message}`}</li>
-        </ul>
-      </div>
+    const { data: commonsPlus } = useBackend(
+        [`/api/commons/plus?id=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/commons/plus",
+            params: {
+                id: commonsId,
+            },
+        }
     );
-  };
 
-  // Backend mutation hook
-  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
-    "/api/announcements/all",
-  ]);
+    const commonsName = commonsPlus?.commons.name;
 
-  // Form submission handler
-  const submitAction = async (data) => {
-    mutation.mutate(data);
-  };
+    const onSuccess = (announcement) => {
+        toast(
+          <div>
+            <p>Announcement successfully created!</p>
+            <ul>
+              <li>{`ID: ${announcement.id}`}</li>
+              <li>{`Start Date: ${announcement.startDate}`}</li>
+              <li>{`End Date: ${announcement.endDate}`}</li>
+              <li>{`Announcement: ${announcement.message}`}</li>
+            </ul>
+          </div>
+        );
+      };
+   
+    // Stryker disable all
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/announcements/all"]
+    );
+    // Stryker restore all
 
-  // Redirect after successful submission
-  if (mutation.isSuccess) {
-    return <Navigate to="/" />;
-  }
+    const submitAction = async (data) => {
+        mutation.mutate(data);
+    }
 
-  return (
-    <BasicLayout>
-      <h2>Create Announcement for { commonsName} </h2>
-      <AnnouncementForm submitAction={submitAction} />
-    </BasicLayout>
-  );
+
+    if (mutation.isSuccess) {
+        return <Navigate to="/" />
+    }
+
+    return (
+        <BasicLayout>
+            <h2>Create Announcement for {commonsName}</h2>
+            <AnnouncementForm
+                submitAction={submitAction}
+            />
+        </BasicLayout>
+    );
+    
 };
 
-export default AdminCreateAnnouncementPage;
+
+export default AdminCreateAnnouncementsPage;

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -6,11 +6,10 @@ import { toast } from "react-toastify"
 
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 
-// Stryker disable all
 const AdminCreateAnnouncementsPage = () => {
 
     const objectToAxiosParams = (newAnnouncement) => ({
-        url: "/api/announcements/new",
+        url: "/api/announcements/post",
         method: "POST",
         data: newAnnouncement
     });
@@ -44,11 +43,13 @@ const AdminCreateAnnouncementsPage = () => {
         );
       };
    
+    // Stryker disable all
     const mutation = useBackendMutation(
         objectToAxiosParams,
         { onSuccess },
-        ["/api/announcements/all"]
+        ["/api/announcements/getbycommonsid"]
     );
+    // Stryker restore all
 
     const submitAction = async (data) => {
         mutation.mutate(data);

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -44,14 +44,11 @@ const AdminCreateAnnouncementsPage = () => {
         );
       };
    
-    // Stryker disable all
     const mutation = useBackendMutation(
         objectToAxiosParams,
         { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
         ["/api/announcements/all"]
     );
-    // Stryker restore all
 
     const submitAction = async (data) => {
         mutation.mutate(data);

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -16,6 +16,7 @@ const AdminCreateAnnouncementsPage = () => {
 
     const { commonsId } = useParams(); 
 
+    // Stryker disable all
     const { data: commonsPlus } = useBackend(
         [`/api/commons/plus?id=${commonsId}`],
         {
@@ -26,6 +27,7 @@ const AdminCreateAnnouncementsPage = () => {
             },
         }
     );
+    // Stryker restore all
 
     const commonsName = commonsPlus?.commons.name;
 

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -9,9 +9,13 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 const AdminCreateAnnouncementsPage = () => {
 
     const objectToAxiosParams = (newAnnouncement) => ({
-        url: "/api/announcements/post",
+        url:`/api/announcements/post/${commonsId}`,
         method: "POST",
-        data: newAnnouncement
+        params: {
+            announcementText: newAnnouncement.announcementText,
+            startdate: newAnnouncement.startDate,
+            enddate: newAnnouncement.endDate,
+        }
     });
 
     const { commonsId } = useParams(); 
@@ -39,7 +43,7 @@ const AdminCreateAnnouncementsPage = () => {
               <li>{`ID: ${announcement.id}`}</li>
               <li>{`Start Date: ${announcement.startDate}`}</li>
               <li>{`End Date: ${announcement.endDate}`}</li>
-              <li>{`Announcement: ${announcement.message}`}</li>
+              <li>{`Announcement: ${announcement.announcementText}`}</li>
             </ul>
           </div>
         );

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -13,8 +13,8 @@ const AdminCreateAnnouncementsPage = () => {
         method: "POST",
         params: {
             announcementText: newAnnouncement.announcementText,
-            startdate: newAnnouncement.startDate,
-            enddate: newAnnouncement.endDate,
+            startDate: newAnnouncement.startDate,
+            endDate: newAnnouncement.endDate,
         }
     });
 

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -11,7 +11,7 @@ import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 const mockedNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
-    ...jest.requireActual("react-router-dom"), 
+    ...jest.requireActual("react-router-dom"),
     useParams: () => ({
         commonsId: 1,
     }),

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,22 +1,35 @@
-import { render, screen } from "@testing-library/react";
-import {QueryClient, QueryClientProvider} from "react-query";
-import {MemoryRouter} from "react-router-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
 import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
-import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
-import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
-import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+    const originalModule = jest.requireActual("react-router-dom");
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => {
+            mockedNavigate(x);
+            return null;
+        },
+    };
+});
 
-jest.mock("react-router-dom", () => ({
-    ...jest.requireActual("react-router-dom"),
-    useParams: () => ({
-        commonsId: 1,
-    }),
-    useNavigate: () => mockedNavigate
-}));
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+    const originalModule = jest.requireActual("react-toastify");
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x),
+    };
+});
 
 describe("AdminCreateAnnouncementsPage tests", () => {
     const axiosMock = new AxiosMockAdapter(axios);
@@ -25,49 +38,88 @@ describe("AdminCreateAnnouncementsPage tests", () => {
     beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {commons: { id: 1, name: "Sample Commons", }, totalPlayers: 5, totalCows: 5,});
+        axiosMock.onGet("/api/commons/plus").reply(200, {
+            commons: { name: "Test Commons" },
+        });
     });
 
-    test("renders page without crashing", async () => {
+    test("renders without crashing", async () => {
         render(
             <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
+                <MemoryRouter initialEntries={["/admin/announcements/create/1"]}>
                     <AdminCreateAnnouncementsPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText("Create Announcement for Sample Commons")).toBeInTheDocument();
-
+        expect(await screen.findByText("Create Announcement for Test Commons")).toBeInTheDocument();
     });
 
-    test("correct href for create announcements button as an admin", async () => {   
-        axiosMock
-            .onGet("/api/currentUser")
-            .reply(200, apiCurrentUserFixtures.adminUser);
-        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
-            commons: {
-                id: 1,
-                name: "Sample Commons",
-            },
-            totalPlayers: 5,
-            totalCows: 5,
-        });
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AdminAnnouncementsPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-      
-        const createButton = await screen.findByText("Create Announcement");
-        expect(createButton).toHaveAttribute("href", "/admin/announcements/1/create");        
-
+    test("When you fill in form and click submit, the right things happen", async () => {
+        
+    // Mocking the POST response
+    axiosMock.onPost("/api/announcements/post").reply(200, {
+        id: 42,
+        startDate: "2023-11-21T17:52:33.000",
+        endDate: "2024-11-21T17:52:33.000",
+        message: "Test announcement",
     });
 
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={["/admin/announcements/create/1"]}>
+                <AdminCreateAnnouncementsPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
 
+    expect(await screen.findByText("Create Announcement for Test Commons")).toBeInTheDocument();
+
+    // Locate form fields and submit button
+    const startDateField = screen.getByLabelText("Start Date");
+    const endDateField = screen.getByLabelText("End Date");
+    const messageField = screen.getByLabelText("Announcement");
+    const submitButton = screen.getByTestId("AnnouncementForm-submit");
+
+    // Simulate filling out the form with proper ISO format for the dates
+    fireEvent.change(startDateField, { target: { value: "2023-11-21T17:52:33" } });
+    fireEvent.change(endDateField, { target: { value: "2024-11-21T17:52:33" } });
+    fireEvent.change(messageField, { target: { value: "Test announcement" } });
+
+    // Submit the form
+    fireEvent.click(submitButton);
+
+    // Wait for the API call to be triggered
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    // Verify sent to backend
+    const expectedAnnouncement = {
+        startDate: "2023-11-21T17:52:33.000",
+        endDate: "2024-11-21T17:52:33.000",
+        announcementText: "Test announcement",
+    };
+
+    expect(JSON.parse(axiosMock.history.post[0].data)).toEqual(expectedAnnouncement);
+
+    // Verify the toast notification
+    expect(mockToast).toBeCalledWith(
+        <div>
+            <p>Announcement successfully created!</p>
+            <ul>
+                <li>ID: 42</li>
+                <li>Start Date: 2023-11-21T17:52:33.000</li>
+                <li>End Date: 2024-11-21T17:52:33.000</li>
+                <li>Announcement: Test announcement</li>
+            </ul>
+        </div>
+    );
+
+    // Verify navigation
+    expect(mockedNavigate).toBeCalledWith({ to: "/" });
+});
+
+    
+    
 });

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -11,7 +11,7 @@ import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 const mockedNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
-    ...jest.requireActual("react-router-dom"),
+    ...jest.requireActual("react-router-dom"), 
     useParams: () => ({
         commonsId: 1,
     }),

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -27,6 +27,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {commons: { id: 1, name: "Sample Commons", }, totalPlayers: 5, totalCows: 5,});
     });
 
     test("renders page without crashing", async () => {
@@ -38,7 +39,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText("Create Announcement")).toBeInTheDocument();
+        expect(await screen.findByText("Create Announcement for Sample Commons")).toBeInTheDocument();
 
     });
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -46,9 +46,9 @@ public class AnnouncementsController extends ApiController{
 
     @Operation(summary = "Create an announcement", description = "Create an announcement associated with a specific commons")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
-    @PostMapping("/post")
+    @PostMapping("/post/{commonsId}")
     public ResponseEntity<Object> createAnnouncement(
-        @Parameter(description = "The id of the common") @RequestParam Long commonsId,
+        @Parameter(description = "The id of the common") @PathVariable Long commonsId,
         @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
         @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import edu.ucsb.cs156.happiercows.entities.Announcement;
 import edu.ucsb.cs156.happiercows.repositories.AnnouncementRepository;
@@ -49,10 +50,16 @@ public class AnnouncementsController extends ApiController{
     @PostMapping("/post/{commonsId}")
     public ResponseEntity<Object> createAnnouncement(
         @Parameter(description = "The id of the common") @PathVariable Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
+        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") 
+        @RequestParam(required = false) 
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) // Ensures the date-time format with timezone offset is accepted
+        Date startDate,
+        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") 
+        @RequestParam(required = false) 
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) // Ensures the date-time format with timezone offset is accepted
+        Date endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
-
+        
         User user = getCurrentUser().getUser();
         Long userId = user.getId();
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -87,7 +87,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
 
         //act 
-        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&startDate={start}&endDate={end}&announcementText={announcement}", commonsId, start, end, announcement).with(csrf()))
+        MvcResult response = mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, start, end, announcement).with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -120,7 +120,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&startDate={start}&announcementText={announcement}", commonsId, start, announcement).with(csrf()))
+        MvcResult response = mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, start, announcement).with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -149,7 +149,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&announcementText={announcement}", commonsId, announcement).with(csrf()))
+        MvcResult response = mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, announcement).with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -177,7 +177,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&startDate={start}&announcementText={announcement}", commonsId, start, announcement).with(csrf()))
+        mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, start, announcement).with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -206,7 +206,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&startDate={start}&endDate={end}&announcementText={announcement}", commonsId, start, end, announcement).with(csrf()))
+        mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, start, end, announcement).with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -233,7 +233,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
 
         //act 
-        mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&startDate={start}&announcementText={announcement}", commonsId, start, announcement).with(csrf()))
+        mockMvc.perform(post("/api/announcements/post/{commonsId}?announcementText={announcement}", commonsId, start, announcement).with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert


### PR DESCRIPTION
## Overview
Fixed:
- POST for create announcements to no longer require commonsId as an input and instead be implicitly set. 
- Difference in formatting for date/time between frontend and backend 
- Start date now defaults to current date/time if a start date is not set.

## Screenshots (Optional)
Announcements with no start date:
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/71807ae6-9ebc-443d-bbb4-45bcab18e423">
Announcements with start date:
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/10294887-05aa-49b9-9380-962e7b344645">
Announcements with both start and end date:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/65106253-9495-4345-94dd-406e01de94c1">

## Validation
1. Click on "Admins" in the top bar and click on "List Commons".
2. Scroll to the far right on the table and click on "Announcements". (Note the commonsId)
3. Click on "Create Announcement".
4. Create an announcement.
5. Click on Swagger in the top bar. 
6. Scroll down to "Announcements" and click on "Get all announcements"
7. Enter in the commonsId of the commons tested earlier and verify announcements have been posted.

## Tests
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Development Deployment Link
https://happycows-dev-yixuan-wong.dokku-12.cs.ucsb.edu 

## Linked Issues
Closes #32 
