### PR TITLE
Javin - Overhauled/refactored the CRUD operation for editing announcements

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
-
+import AdminEditAnnouncementsPage from "main/pages/AdminEditAnnouncementsPage";
 function App() {
     const { data: currentUser } = useCurrentUser();
 
@@ -57,6 +57,10 @@ function App() {
             <Route
                 path="/admin/announcements/:commonsId/create"
                 element={<AdminCreateAnnouncementsPage />}
+            />
+            <Route
+                path="/admin/announcements/edit/:id"
+                element={<AdminEditAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/components/Announcement/AnnouncementTable.js
+++ b/frontend/src/main/components/Announcement/AnnouncementTable.js
@@ -11,7 +11,7 @@ export default function AnnouncementTable({ announcements, currentUser }) {
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/announcements/edit/${cell.row.values.id}`)
+        navigate(`/admin/announcements/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -27,7 +27,7 @@ export default function AdminAnnouncementsPage() {
 
     const commonsName = commonsPlus?.commons.name;
 
-    const { data: announcements, error: _error, status: _status } = useBackend(
+    const { data: response, error: _error, status: _status } = useBackend(
       [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
       {
           method: "GET",
@@ -37,7 +37,9 @@ export default function AdminAnnouncementsPage() {
           },
       },
       []
-  );
+    );
+    const announcements = response?.content || [];
+
 
     return (
       <BasicLayout>

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -4,8 +4,12 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { Row, Col } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import { useBackend } from "main/utils/useBackend";
+import AnnouncementTable from "main/components/Announcement/AnnouncementTable"
+import { useCurrentUser } from "main/utils/currentUser";
+
 
 export default function AdminAnnouncementsPage() {
+    const { data: currentUser } = useCurrentUser(); 
     const { commonsId } = useParams();
 
     // Stryker disable all
@@ -23,8 +27,20 @@ export default function AdminAnnouncementsPage() {
 
     const commonsName = commonsPlus?.commons.name;
 
+    const { data: announcements } = useBackend(
+      [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
+      {
+          method: "GET",
+          url: "/api/announcements/getbycommonsid",
+          params: {
+              commonsID: commonsId,
+          },
+      }
+  );
+
     return (
-        <BasicLayout>
+      <BasicLayout>
+
         <div className="pt-2">
           <Row  className="pt-5">
             <Col>
@@ -32,6 +48,14 @@ export default function AdminAnnouncementsPage() {
               <Button variant = "primary" href = {`/admin/announcements/${commonsId}/create`} >
                 Create Announcement
               </Button>
+            </Col>
+          </Row>
+
+
+          <Row  className="pt-5">
+            <Col>
+              <h2>Announcements</h2>
+              <AnnouncementTable announcements={announcements} currentUser={currentUser} />
             </Col>
           </Row>
         </div>

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -27,15 +27,16 @@ export default function AdminAnnouncementsPage() {
 
     const commonsName = commonsPlus?.commons.name;
 
-    const { data: announcements } = useBackend(
+    const { data: announcements, error: _error, status: _status } = useBackend(
       [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
       {
           method: "GET",
           url: "/api/announcements/getbycommonsid",
           params: {
-              commonsID: commonsId,
+              commonsId: commonsId,
           },
-      }
+      },
+      []
   );
 
     return (
@@ -45,17 +46,10 @@ export default function AdminAnnouncementsPage() {
           <Row  className="pt-5">
             <Col>
               <h2>Announcements for Commons: {commonsName}</h2>
+              <AnnouncementTable announcements={announcements} currentUser={currentUser} />
               <Button variant = "primary" href = {`/admin/announcements/${commonsId}/create`} >
                 Create Announcement
               </Button>
-            </Col>
-          </Row>
-
-
-          <Row  className="pt-5">
-            <Col>
-              <h2>Announcements</h2>
-              <AnnouncementTable announcements={announcements} currentUser={currentUser} />
             </Col>
           </Row>
         </div>

--- a/frontend/src/main/pages/AdminEditAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminEditAnnouncementsPage.js
@@ -1,0 +1,70 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function AdminEditAnnouncementsPage() {
+  let { id } = useParams();
+
+  const { data: announcement, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/announcements?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/announcements`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (announcement) => ({
+    url: "/api/announcements/update",
+    method: "PUT",
+    params: {
+      id: announcement.id,
+    },
+    data: {
+        "announcementText": announcement.announcementText,
+        "startDate": announcement.startDate,
+        "endDate": announcement.endDate,
+    }
+  });
+
+  const onSuccess = (_, announcement) => {
+    toast(`Announcement Updated - id: ${announcement.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/announcement?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const submitAction = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/admin/announcements" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Announcements</h1>
+        {announcement &&
+          <AnnouncementForm initialAnnouncement={announcement} submitAction={submitAction} buttonLabel="Update" />
+        }
+      </div>
+    </BasicLayout>
+  )
+}
+

--- a/frontend/src/main/pages/AdminEditAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminEditAnnouncementsPage.js
@@ -11,10 +11,10 @@ export default function AdminEditAnnouncementsPage() {
   const { data: announcement, _error, _status } =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/announcements?id=${id}`],
+      [`/api/announcements/getbyid?id=${id}`],
       {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
         method: "GET",
-        url: `/api/announcements`,
+        url: `/api/announcements/getbyid`,
         params: {
           id
         }
@@ -23,15 +23,19 @@ export default function AdminEditAnnouncementsPage() {
 
 
   const objectToAxiosPutParams = (announcement) => ({
-    url: "/api/announcements/update",
+    url: "/api/announcements/put",
     method: "PUT",
     params: {
       id: announcement.id,
+      commonsId: announcement.commonsId,
+      startDate: announcement.startDate,
+      endDate: announcement.endDate,
+      announcementText: announcement.announcementText,
     },
     data: {
-        "announcementText": announcement.announcementText,
         "startDate": announcement.startDate,
         "endDate": announcement.endDate,
+        "announcementText": announcement.announcementText,
     }
   });
 
@@ -43,7 +47,7 @@ export default function AdminEditAnnouncementsPage() {
     objectToAxiosPutParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [`/api/announcement?id=${id}`]
+    [`/api/announcements/getbyid?id=${id}`]
   );
 
   const { isSuccess } = mutation
@@ -53,15 +57,15 @@ export default function AdminEditAnnouncementsPage() {
   }
 
   if (isSuccess) {
-    return <Navigate to="/admin/announcements" />
+    return <Navigate to="/admin/announcements/1" />
   }
 
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit Announcements</h1>
+        <h1>Edit Announcement</h1>
         {announcement &&
-          <AnnouncementForm initialAnnouncement={announcement} submitAction={submitAction} buttonLabel="Update" />
+          <AnnouncementForm initialContents={announcement} submitAction={submitAction} buttonLabel="Update" />
         }
       </div>
     </BasicLayout>

--- a/frontend/src/stories/pages/AdminEditAnnouncementsPage.stories.js
+++ b/frontend/src/stories/pages/AdminEditAnnouncementsPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import AdminEditAnnouncementsPage from 'main/pages/AdminEditAnnouncementsPage';
+
+export default {
+    title: 'pages/AdminEditAnnouncementsPage',
+    component: AdminEditAnnouncementsPage
+};
+
+const Template = () => <AdminEditAnnouncementsPage />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
As described in #30 the Put operation for announcements was implemented poorly. It now properly takes a whole object as its response body. It no longer fails to parse date/time strings. The tests also have been changed so that they properly test what is actually happening on the backend; before, the tests passed but Swagger was very hard to use and get anything but an error 400. Additionally, the PUT operation for announcements now works the same as the PUT operation for commons, and it's weird that they worked totally different before.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![Generic placeholder image](https://picsum.photos/640/480)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
On the deployment, play around with the PUT operation for announcements on Swagger. You should be able to see that errors in the structure of the request will be caught - for example, you shouldn't be able to edit an Announcement to have an empty text field or a start date that occurs after its end date.
## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #30.
