### PR TITLE
Javin - Refactor announcements PUT operation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -14,19 +14,28 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import java.util.Date;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+
 
 import edu.ucsb.cs156.happiercows.entities.Announcement;
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.repositories.AnnouncementRepository;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.models.CreateAnnouncementParams;
+import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 
 import org.springframework.security.core.Authentication;
 import java.util.Date;
 
 
 import java.util.Optional;
+
+import javax.validation.Valid;
 
 @Tag(name = "Announcements")
 @RequestMapping("/api/announcements")
@@ -133,54 +142,28 @@ public class AnnouncementsController extends ApiController{
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @PutMapping("/put")
     public ResponseEntity<Object> editAnnouncement(
-        @Parameter(description = "The id of the announcement") @RequestParam Long id,
-        @Parameter(description = "The id of the common") @RequestParam Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
-        @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
+            @Parameter(name="id") @RequestParam long id,
+            @Parameter(name="request body") @RequestBody CreateAnnouncementParams params) {
+        Optional<Announcement> existing = announcementRepository.findByAnnouncementId(id);
 
-        User user = getCurrentUser().getUser();
-        Long userId = user.getId();
+        Announcement updated;
+        HttpStatus status;
 
-        // Make sure the user is part of the commons or is an admin
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
-            log.info("User is not an admin");
-            Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
-
-            if (!userCommonsLookup.isPresent()) {
-                return ResponseEntity.badRequest().body("Commons_id must exist.");
-            }
+        if (existing.isPresent()) {
+            updated = existing.get();
+            status = HttpStatus.OK;
+        } else {
+            updated = new Announcement();
+            throw new EntityNotFoundException(Announcement.class, id);
         }
-
-        if (announcementText == "") {
-            return ResponseEntity.badRequest().body("Announcement cannot be empty.");
-        }
-
-        if (startDate == null) {
-            log.info("Start date not specified. Defaulting to current date.");
-            startDate = new Date();
-        }
-
-        if (endDate != null && startDate.after(endDate)) {
-            return ResponseEntity.badRequest().body("Start date must be before end date.");
-        }
-
-        Optional<Announcement> announcementLookup = announcementRepository.findByAnnouncementId(id);
-
-        if (!announcementLookup.isPresent()) {
-            return ResponseEntity.badRequest().body("Announcement could not be found. Invalid id.");
-        }
-
-        // Create the announcement
-        Announcement announcementObj = announcementLookup.get();
-        announcementObj.setStartDate(startDate);
-        announcementObj.setEndDate(endDate);
-        announcementObj.setAnnouncementText(announcementText);
-
-        // Save the announcement
-        announcementRepository.save(announcementObj);
-        return ResponseEntity.ok(announcementObj);
+        // updated.setId(params.getId());
+        // updated.setCommonsId(params.getCommonsId());
+        updated.setAnnouncementText(params.getAnnouncementText());
+        updated.setEndDate(params.getEndDate());
+        updated.setStartDate(params.getStartDate());
+        
+        announcementRepository.save(updated);
+        return ResponseEntity.status(status).build();
     }
 
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -182,7 +182,7 @@ public class AnnouncementsController extends ApiController{
 
         // The provided announcement text must not be empty or missing.
         if (params.getAnnouncementText() == null || params.getAnnouncementText().equals("")) {
-            throw new IllegalArgumentException("Announcement Text cannot be empty");
+            throw new IllegalArgumentException("Announcement Text cannot be empty.");
         }
         else {
             updated.setAnnouncementText(params.getAnnouncementText());
@@ -205,7 +205,7 @@ public class AnnouncementsController extends ApiController{
             }
         }
         announcementRepository.save(updated);
-        return ResponseEntity.status(status).build();
+        return ResponseEntity.ok(updated);
     }
 
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -187,15 +187,6 @@ public class AnnouncementsController extends ApiController{
             updated.setAnnouncementText(params.getAnnouncementText());
         }
 
-        // At this point we know that the announcement exists. So we can 
-        // also check if the user has admin permissions.
-        // Make sure the user is an admin
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
-            log.info("User is not an admin, so they may not edit announcements.");
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
         announcementRepository.save(updated);
         return ResponseEntity.ok(updated);
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateAnnouncementParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateAnnouncementParams.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.NumberFormat;
+import java.util.Date;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class CreateAnnouncementParams {
+    @DateTimeFormat
+    private Date startDate;
+    @DateTimeFormat
+    private Date endDate;
+
+    private String announcementText;
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -512,17 +512,82 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
 
         UserCommons userCommons = UserCommons.builder().build();
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
-
+        
+        // Expected values of the edited announcement, which has no start date
+        String editedAnnouncement = "Hello world edited!";
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
+        Date editedEnd = sdf.parse("2025-03-03T17:39:43.000-08:00");
+        
+        // request body
+        String requestBody = "{\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
+        
         //act 
-        MvcResult response = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&announcementText={announcement}", id, commonsId, announcement).with(csrf()))
+        MvcResult response =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByAnnouncementId(id);
         verify(announcementRepository, atLeastOnce()).save(any(Announcement.class));
-        String responseString = response.getResponse().getContentAsString();
-        String expectedResponseString = mapper.writeValueAsString(announcementObj);
-        assertEquals(expectedResponseString, responseString);
+
+        String editedResponseString = mapper.writeValueAsString(announcementRepository.findByAnnouncementId(id));
+        // The start date of the edited announcementObj will be automatically set to the current date/time
+        // so every time you run this test it'll actually be different.
+        // That's why we have to use real obj's start date in expectedAnnouncementObj
+        // to eliminate the strange race condition.
+        Date defaultGenerated = announcementRepository.findByAnnouncementId(id).get().getStartDate();
+        Announcement expectedAnnouncementObj = Announcement.builder().id(id).startDate(defaultGenerated).commonsId(commonsId).endDate(editedEnd).announcementText(editedAnnouncement).build();
+        String editedExpectedResponseString = mapper.writeValueAsString(expectedAnnouncementObj);
+        assertEquals(editedExpectedResponseString, editedResponseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCanEditAnnouncementWithoutAnyDates() throws Exception {
+
+        // arrange
+        Long id = 0L;
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String announcement = "Hello world!";
+
+        Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).announcementText(announcement).build();
+        when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+        
+        // Expected values of the edited announcement, which has no start date
+        String editedAnnouncement = "Hello world edited!";
+        
+        // request body
+        String requestBody = "{\"announcementText\":\"Hello world edited!\"}";
+        
+        //act 
+        MvcResult response =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(announcementRepository, atLeastOnce()).findByAnnouncementId(id);
+        verify(announcementRepository, atLeastOnce()).save(any(Announcement.class));
+
+        String editedResponseString = mapper.writeValueAsString(announcementRepository.findByAnnouncementId(id));
+        // The start date of the edited announcementObj will be automatically set to the current date/time
+        // so every time you run this test it'll actually be different.
+        // That's why we have to use real obj's start date in expectedAnnouncementObj
+        // to eliminate the strange race condition.
+        Date defaultGenerated = announcementRepository.findByAnnouncementId(id).get().getStartDate();
+        Announcement expectedAnnouncementObj = Announcement.builder().id(id).startDate(defaultGenerated).commonsId(commonsId).announcementText(editedAnnouncement).build();
+        String editedExpectedResponseString = mapper.writeValueAsString(expectedAnnouncementObj);
+        assertEquals(editedExpectedResponseString, editedResponseString);
     }
 
     @WithMockUser(roles = {"USER"})
@@ -544,12 +609,15 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
 
         //act 
-        MvcResult response = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&startDate={start}&announcementText={announcement}", id, commonsId, start, announcement).with(csrf()))
-            .andExpect(status().isBadRequest()).andReturn();
-
-        // assert
-        verify(announcementRepository, times(0)).findByAnnouncementId(id);
-        verify(announcementRepository, times(0)).save(any(Announcement.class));
+        
+        //act 
+        String requestBody = "{\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
+        MvcResult response =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
     }
 
     @WithMockUser(roles = {"USER"})
@@ -560,10 +628,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long commonsId = 1L;
         Long userId = 1L;
-        String announcement = "Hello world!";
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
 
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.empty());
 
@@ -571,8 +637,14 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        MvcResult response = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&startDate={start}&announcementText={announcement}", id, commonsId, start, announcement).with(csrf()))
-            .andExpect(status().isBadRequest()).andReturn();
+        String requestBody = "{\"startDate\":\"2024-03-03T17:39:43.000-08:00\",\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
+        MvcResult response =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isNotFound()).andReturn();
+
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByAnnouncementId(id);
@@ -598,13 +670,21 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         UserCommons userCommons = UserCommons.builder().build();
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
-        //act 
-        MvcResult response = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&startDate={start}&announcementText={announcement}", id, commonsId, start, announcement).with(csrf()))
+        //act (NULL announcement text)
+        String requestBody = "{\"startDate\":\"2024-03-03T17:39:43.000-08:00\",\"endDate\":\"2025-03-03T17:39:43.000-08:00\"}";
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
-
-        // assert
-        verify(announcementRepository, times(0)).findByAnnouncementId(id);
-        verify(announcementRepository, times(0)).save(any(Announcement.class));
+        
+        //act (Provided, but EMPTY announcement text)
+        requestBody = "{\"startDate\":\"2024-03-03T17:39:43.000-08:00\",\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"\"}";
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
     }
 
     @WithMockUser(roles = {"USER"})
@@ -618,8 +698,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         String announcement = "Announcement";
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
+        // The initial start/end times should be okay, since we want to make sure the editing is wrong
         Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2022-03-03T17:39:43.000-08:00");
+        Date end = sdf.parse("2026-03-03T17:39:43.000-08:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -628,11 +709,12 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        MvcResult response = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&startDate={start}&endDate={end}&announcementText={announcement}", id, commonsId, start, end, announcement).with(csrf()))
+        String requestBody = "{\"startDate\":\"2024-03-03T17:39:43.000-08:00\",\"endDate\":\"2022-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
+        MvcResult response =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
-
-        // assert
-        verify(announcementRepository, times(0)).findByAnnouncementId(id);
-        verify(announcementRepository, times(0)).save(any(Announcement.class));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -496,9 +496,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         assertEquals(editedExpectedResponseString, editedResponseString);
     }
 
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     @Test
-    public void userCanEditAnnouncementWithoutStart() throws Exception {
+    public void adminCanEditAnnouncementWithoutStart() throws Exception {
 
         // arrange
         Long id = 0L;
@@ -544,9 +544,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         assertEquals(editedExpectedResponseString, editedResponseString);
     }
 
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     @Test
-    public void userCanEditAnnouncementWithoutAnyDates() throws Exception {
+    public void adminCanEditAnnouncementWithoutAnyDates() throws Exception {
 
         // arrange
         Long id = 0L;
@@ -591,7 +591,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = {"USER"})
     @Test
-    public void userCannotEditAnnouncementIfNotInCommons() throws Exception {
+    public void regularUserCannotEditAnnouncement() throws Exception {
 
         // arrange
         Long id = 0L;
@@ -604,11 +604,10 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
-
-        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
-
-        //act 
         
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));        
+       
         //act 
         String requestBody = "{\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
         MvcResult response =
@@ -619,9 +618,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
             .andExpect(status().isForbidden()).andReturn();
     }
 
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     @Test
-    public void userCannotEditAnnouncementThatDoesNotExist() throws Exception {
+    public void adminCannotEditAnnouncementThatDoesNotExist() throws Exception {
 
         // arrange
         Long id = 0L;
@@ -650,9 +649,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         verify(announcementRepository, times(0)).save(any(Announcement.class));
     }
 
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     @Test
-    public void userCannotEditAnnouncementToHaveEmptyStringAsAnnouncement() throws Exception {
+    public void adminCannotEditAnnouncementToHaveEmptyStringAsAnnouncement() throws Exception {
 
         // arrange
         Long id = 0L;
@@ -693,9 +692,9 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         assertEquals("Announcement Text cannot be empty.", response.getResolvedException().getMessage());
     }
 
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     @Test
-    public void userCannotEditAnnouncementToHaveEndBeforeStart() throws Exception {
+    public void adminCannotEditAnnouncementToHaveEndBeforeStart() throws Exception {
 
         // arrange
         Long id = 0L;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -448,7 +449,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
     public void adminCanEditAnnouncement() throws Exception {
 
 
-        Long id = 0L;
+        Long id = 19090L;
         Long commonsId = 1L;
         String announcement = "Hello world!";
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
@@ -477,14 +478,21 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Announcement editedAnnouncementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(editedStart).endDate(editedEnd).announcementText(editedAnnouncement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
 
-        //act 
-        MvcResult editedResponse = mockMvc.perform(put("/api/announcements/put?id={id}&commonsId={commonsId}&startDate={start}&endDate={end}&announcementText={announcement}", id, commonsId, editedStart, editedEnd, editedAnnouncement).with(csrf()))
+        // String requestBody = mapper.writeValueAsString(editedAnnouncementObj);
+        String requestBody = "{\"startDate\":\"2023-03-03T17:39:43.000-08:00\",\"endDate\":\"2025-03-03T17:39:43.000-08:00\",\"announcementText\":\"Hello world edited!\"}";
+        // //act 
+        MvcResult editedResponse =
+            mockMvc.perform(put("/api/announcements/put?id={id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody)
+            .with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByAnnouncementId(id);
         verify(announcementRepository, atLeastOnce()).save(any(Announcement.class));
-        String editedResponseString = editedResponse.getResponse().getContentAsString();
+
+        String editedResponseString = mapper.writeValueAsString(announcementRepository.findByAnnouncementId(id));
         String editedExpectedResponseString = mapper.writeValueAsString(editedAnnouncementObj);
         assertEquals(editedExpectedResponseString, editedResponseString);
     }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
As described in #30 the Put operation for announcements was implemented poorly. 
- It now properly takes a whole object as its response body. It no longer fails to parse date/time strings. 
- The PUT operation for announcements now works the same as the PUT operation for commons, and it's weird that they worked totally different before.
- Upon trying to edit an announcement that doesn't exist, PUT correctly returns an error 404, not 400. For reference, the previous implementation did things like this for every error, naming them all as BadRequest for some reason when they clearly should have had a different response code:
![image](https://github.com/user-attachments/assets/28aee14e-f0cd-42c8-b0b8-52a608302824)
This made Swagger super hard to test and diagnose!
- PUT throws an error 403 (Forbidden) if your permissions are not correct. Before, there were situations where this would throw an error 400.
- Doesn't throw an undocumented response code 204 anymore upon receiving bad input. That wasn't helpful.
- The tests have all been overhauled to support the new changes.

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
PUT looks like this now on Swagger. I didn't edit the frontend for this issue.
![image](https://github.com/user-attachments/assets/7ca4e960-8377-453b-b85a-3b14ad4ae4ef)
And here's an example 404 error:
![image](https://github.com/user-attachments/assets/e4f60bee-3868-4e2f-bc48-fdda96afcc17)

## Deployment
https://happycows-dev-jzipkin1812.dokku-12.cs.ucsb.edu

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
On the deployment, play around with the PUT operation for announcements on Swagger. You should be able to see that errors in the structure of the request will be caught - for example, you shouldn't be able to edit an Announcement to have an empty text field or a start date that occurs after its end date.
## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #30.
