### PR TITLE
yungong - try to add tests for ManageCows

### DIFF
--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -43,7 +43,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
                                 <Button
                                     variant="outline-success"
                                     onClick={() => {
-                                        setMessage("buy");
+                                        setMessage("Buy");
                                         openModal();
                                     }}
                                     data-testid={"buy-cow-button"}
@@ -55,7 +55,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
                                 <Button
                                     variant="outline-danger"
                                     onClick={() => {
-                                        setMessage("sell");
+                                        setMessage("Sell");
                                         openModal();
                                     }}
                                     data-testid={"sell-cow-button"}

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -9,10 +9,10 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
     const { data: currentUser } = useCurrentUser();
     let { userId } = useParams();
     userId = userId ? parseInt(userId, 10) : NaN;
-    // Stryker disable all
+    
     const isViewOnly = hasRole(currentUser, "ROLE_ADMIN") && !isNaN(userId);
 
-    // Stryker restore all
+    
     return (
         <Card>
             <Card.Header as="h5" className= "woodenboardtable" >Manage Cows</Card.Header>

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -43,7 +43,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
                                 <Button
                                     variant="outline-success"
                                     onClick={() => {
-                                        setMessage("Buy");
+                                        setMessage("buy");
                                         openModal();
                                     }}
                                     data-testid={"buy-cow-button"}
@@ -55,7 +55,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
                                 <Button
                                     variant="outline-danger"
                                     onClick={() => {
-                                        setMessage("Sell");
+                                        setMessage("sell");
                                         openModal();
                                     }}
                                     data-testid={"sell-cow-button"}

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import ManageCows from "main/components/Commons/ManageCows";
-
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import userCommonsFixtures from "fixtures/userCommonsFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useParams } from "react-router-dom";
@@ -139,5 +139,33 @@ describe("ManageCows tests", () => {
         fireEvent.click(screen.getByTestId("sell-cow-button"));
         expect(mockSetMessage).toHaveBeenCalledWith("Sell");
         expect(mockOpenModal).toHaveBeenCalled();
+    });
+
+    test("tests for ADMIN has role", () => {
+        useParams.mockReturnValue({ userId: 1 });
+        const currentUser = currentUserFixtures.adminUser;
+
+        currentUserModule.useCurrentUser.mockReturnValue({
+            data: {
+                root: {
+                    user: {
+                        id: 1,
+                    },
+                },
+            },
+        });
+        
+        const hasRoleSpy = jest.spyOn(currentUserModule, 'hasRole');
+        
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ManageCows
+                    userCommons={userCommonsFixtures.oneUserCommons[0]}
+                    setMessage={mockSetMessage}
+                    openModal={mockOpenModal}
+                    currentUser={currentUser}
+                />
+            </QueryClientProvider>
+        );
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -142,29 +142,19 @@ describe("ManageCows tests", () => {
     });
 
     test("tests for ADMIN has role", () => {
-        const currentUser = currentUserFixtures.adminUser;
+        currentUserModule.useCurrentUser.mockReturnValue({ data: null });
         useParams.mockReturnValue({ userId: 1 });
 
-        currentUserModule.useCurrentUser.mockReturnValue({
-            data: {
-                root: {
-                    user: {
-                        id: 1,
-                    },
-                },
-            },
-        });
-        currentUserModule.hasRole.mockReturnValue(true);
+        currentUserModule.hasRole.mockReturnValue(false);
         render(
             <QueryClientProvider client={queryClient}>
                 <ManageCows
                     userCommons={userCommonsFixtures.oneUserCommons[0]}
                     setMessage={mockSetMessage}
                     openModal={mockOpenModal}
-                    currentUser={currentUser}
                 />
             </QueryClientProvider>
         );
-        expect(screen.getByTestId("ManageCows-ViewOnly")).toHaveTextContent("This page is for viewing only, cannot buy and sell cows.");
+        expect(screen.queryByTestId("ManageCows-ViewOnly")).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -167,6 +167,7 @@ describe("ManageCows tests", () => {
                 />
             </QueryClientProvider>
         );
+        // the use of expect.anything is documented in the link: https://jsr.io/@std/expect/doc/~/expect.anything
         expect(currentUserModule.hasRole).toHaveBeenCalledWith(
             expect.anything(),
             "ROLE_ADMIN"

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -165,5 +165,6 @@ describe("ManageCows tests", () => {
                 />
             </QueryClientProvider>
         );
+        expect(screen.getByTestId("ManageCows-ViewOnly")).toHaveTextContent("This page is for viewing only, cannot buy and sell cows.");
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -142,8 +142,8 @@ describe("ManageCows tests", () => {
     });
 
     test("tests for ADMIN has role", () => {
-        useParams.mockReturnValue({ userId: 1 });
         const currentUser = currentUserFixtures.adminUser;
+        useParams.mockReturnValue({ userId: 1 });
 
         currentUserModule.useCurrentUser.mockReturnValue({
             data: {
@@ -154,7 +154,7 @@ describe("ManageCows tests", () => {
                 },
             },
         });
-        
+        currentUserModule.hasRole.mockReturnValue(true);
         render(
             <QueryClientProvider client={queryClient}>
                 <ManageCows

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -155,7 +155,9 @@ describe("ManageCows tests", () => {
                 },
             },
         });
-        currentUserModule.hasRole.mockReturnValue(true);
+        currentUserModule.hasRole.mockImplementation((_, role) => {
+            return role === "ROLE_ADMIN";
+        });
         render(
             <QueryClientProvider client={queryClient}>
                 <ManageCows
@@ -165,6 +167,9 @@ describe("ManageCows tests", () => {
                 />
             </QueryClientProvider>
         );
-        expect(screen.queryByTestId("ManageCows-ViewOnly")).toBeInTheDocument();
+        expect(currentUserModule.hasRole).toHaveBeenCalledWith(
+            expect.anything(),
+            "ROLE_ADMIN"
+        );
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import ManageCows from "main/components/Commons/ManageCows";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import userCommonsFixtures from "fixtures/userCommonsFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useParams } from "react-router-dom";
@@ -142,10 +141,21 @@ describe("ManageCows tests", () => {
     });
 
     test("tests for ADMIN has role", () => {
-        currentUserModule.useCurrentUser.mockReturnValue({ data: null });
         useParams.mockReturnValue({ userId: 1 });
 
-        currentUserModule.hasRole.mockReturnValue(false);
+        currentUserModule.useCurrentUser.mockReturnValue({
+            data: {
+                root: {
+                    user: {
+                        id: 1,
+                    },
+                    roles: [{
+                        "authority": "ROLE_ADMIN"
+                    }]
+                },
+            },
+        });
+        currentUserModule.hasRole.mockReturnValue(true);
         render(
             <QueryClientProvider client={queryClient}>
                 <ManageCows
@@ -155,6 +165,6 @@ describe("ManageCows tests", () => {
                 />
             </QueryClientProvider>
         );
-        expect(screen.queryByTestId("ManageCows-ViewOnly")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("ManageCows-ViewOnly")).toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -155,8 +155,6 @@ describe("ManageCows tests", () => {
             },
         });
         
-        const hasRoleSpy = jest.spyOn(currentUserModule, 'hasRole');
-        
         render(
             <QueryClientProvider client={queryClient}>
                 <ManageCows


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
I write a test for `ManageCows.js`, which previously has a `Stryker` exception about the field `isViewOnly`.
https://ucsb-cs156-f24.slack.com/archives/C080R66E326/p1732552002315739

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
before I added the test:
![image](https://github.com/user-attachments/assets/95d73bcc-f254-4d92-a9b1-cd74cf2cf806)



## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. all the GitHub auto tests are passed

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #52
