### PR TITLE
Changed manage cows to have more space between items

### DIFF
--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -19,13 +19,13 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
             <Card.Body style={// Stryker disable next-line all: don't test CSS params
                 {backgroundColor: "rgb(245, 210, 140)"}}>
                 {/* change $10 to info from fixture */}
-                <Card.Title className="text-center">
+                <Card.Title className="text-center" style={{ marginBottom: "15px" }}>
                     💵 Market Cow Price: ${commons?.cowPrice}
                 </Card.Title>
-                <Card.Title className="text-center">
+                <Card.Title className="text-center"style={{ marginBottom: "20px" }}>
                     🐮 Number of Cows: {userCommons.numOfCows}
                 </Card.Title>
-                <Card.Title className="text-center">
+                <Card.Title className="text-center"style={{ marginBottom: "20px" }}>
                     🥛 Current Milk Price: ${commons?.milkPrice}
                 </Card.Title>
                 {/* when the ID doesnt match, dont show the buy/sell button */}
@@ -39,7 +39,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
                 ) : (
                     <>
                         <Row>
-                            <Col className="text-center">
+                            <Col className="text-center" style={{ marginBottom: "20px" }}>
                                 <Button
                                     variant="outline-success"
                                     onClick={() => {


### PR DESCRIPTION
## Overview
In this PR, I added extra space below each item in the Manage Cows column so there is a bigger gap between each item making it easier to read and use.

## Screenshots 
<img width="360" alt="image" src="https://github.com/user-attachments/assets/3aa84db5-8ac1-47b1-b7d9-9baefc118964">

## Validation
1. Download this branch.
2. Run the project.
3. Go to main page.
4. View the changes.

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #62 
